### PR TITLE
Binary search updates

### DIFF
--- a/src/Redis2Go/Helpers/FolderSearch.cs
+++ b/src/Redis2Go/Helpers/FolderSearch.cs
@@ -27,7 +27,16 @@ namespace Redis2Go.Helpers
                 {
                     return null;
                 }
-                currentPath = matchesDirectory.OrderBy(x => x).Last();
+
+                if (matchesDirectory.Length > 1)
+                {
+                    currentPath = matchesDirectory.FirstOrDefault(x => FindFolder(x, @"*\tools") != null) ??
+                                  matchesDirectory.OrderBy(x => x).Last();
+                }
+                else
+                {
+                    currentPath = matchesDirectory.First();
+                }
             }
 
             return currentPath;

--- a/src/Redis2Go/RedisRunner.cs
+++ b/src/Redis2Go/RedisRunner.cs
@@ -1,4 +1,4 @@
-﻿using Redis2Go.Exceptions;
+using Redis2Go.Exceptions;
 using Redis2Go.Helpers;
 using System;
 
@@ -8,6 +8,7 @@ namespace Redis2Go
     {
         private const string BinariesSearchPattern = @"packages\Redis*\tools";
         private const string BinariesSearchPatternSolution = @"Redis*\tools";
+        public const string WindowsNugetCacheLocation = @"%USERPROFILE%\.nuget\packages";
 
         private readonly IRedisProcess _redisProcess;
         private readonly int _port;
@@ -63,8 +64,9 @@ namespace Redis2Go
             get
             {
                 // 1st: path when installed via nuget
-                // 2nd: path when started from solution
+                // 2st: path when installed via nuget using PackageReference
                 string binariesFolder = FolderSearch.CurrentExecutingDirectory().FindFolderUpwards(BinariesSearchPattern) ??
+                                        Environment.ExpandEnvironmentVariables(WindowsNugetCacheLocation).FindFolderUpwards(BinariesSearchPattern) ??
                                         FolderSearch.CurrentExecutingDirectory().FindFolderUpwards(BinariesSearchPatternSolution);
 
                 if (binariesFolder == null)

--- a/src/Redis2Go/RedisRunner.cs
+++ b/src/Redis2Go/RedisRunner.cs
@@ -7,7 +7,7 @@ namespace Redis2Go
     public class RedisRunner : IDisposable
     {
         private const string BinariesSearchPatternSolution = @"Redis*\tools";
-        private static string BinariesSearchPattern = @"packages\Redis*\tools";
+        private static string BinariesSearchPattern = @"packages\Redis*\*\tools";
         public const string WindowsNugetCacheLocation = @"%USERPROFILE%\.nuget\packages";
         private static string BinariesSearchDirectory;
 


### PR DESCRIPTION
I've added a default binary search location for the nuget cache to support package reference configurations.  Also, I added support for overriding the binary search location and pattern if ever necessary.